### PR TITLE
More expressive JSONDecoder errors for xcstrings decoding

### DIFF
--- a/Sources/SwiftGenKit/Parsers/Strings/FileTypeParser/StringsCatalogFileParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Strings/FileTypeParser/StringsCatalogFileParser.swift
@@ -28,7 +28,7 @@ extension Strings {
 
       do {
         return try file.document.strings.compactMap { key, entry -> Strings.Entry? in
-          guard let localization = entry.localizations[sourceLanguage] else {
+          guard let localization = entry.localizations?[sourceLanguage] else {
             return nil
           }
           var stringEntry = Strings.Entry(

--- a/Sources/SwiftGenKit/Parsers/Strings/StringsCatalogFile.swift
+++ b/Sources/SwiftGenKit/Parsers/Strings/StringsCatalogFile.swift
@@ -45,7 +45,7 @@ extension Strings {
 
   struct StringCatalogEntry: Decodable {
     let comment: String?
-    let localizations: [String: Localization]
+    let localizations: [String: Localization]?
   }
 
   struct Localization: Decodable {

--- a/Sources/SwiftGenKit/Parsers/Strings/StringsCatalogFile.swift
+++ b/Sources/SwiftGenKit/Parsers/Strings/StringsCatalogFile.swift
@@ -21,7 +21,18 @@ extension Strings {
 
       do {
         self.document = try JSONDecoder().decode(Document.self, from: data)
-      } catch let error {
+      } catch let DecodingError.dataCorrupted(context) {
+        throw ParserError.invalidFormat(reason: context.debugDescription)
+      } catch let DecodingError.keyNotFound(key, context) {
+        let message = "Key '\(key)' not found:\(context.debugDescription)\ncodingPath:\(context.codingPath)"
+        throw ParserError.invalidFormat(reason: message)
+      } catch let DecodingError.valueNotFound(value, context) {
+        let message = "Value '\(value)' not found:\(context.debugDescription)\ncodingPath:\(context.codingPath)"
+        throw ParserError.invalidFormat(reason: message)
+      } catch let DecodingError.typeMismatch(type, context)  {
+        let message = "Type '\(type)' mismatch:\(context.debugDescription)\ncodingPath:\(context.codingPath)"
+        throw ParserError.invalidFormat(reason: message)
+      } catch {
         throw ParserError.invalidFormat(reason: error.localizedDescription)
       }
     }


### PR DESCRIPTION
After migration from .strings and moving the .xcstrings file around the project using Xcode 15.4, got .xcstrings that started with` {"sourceLanguage":"en","strings":{"":{},"%@":{}` which produced parsing error - unfortunately I spent around 3h thinking that I'm using SwiftGen incorrectly getting error opaque error message`Error: Invalid format. The data couldn’t be read because it is missing`. 
Adding descriptive parsing error messages.


